### PR TITLE
feature/55 pubchem abbreviations

### DIFF
--- a/src/aoptk/pubchem_abbreviations.py
+++ b/src/aoptk/pubchem_abbreviations.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 from typing import ClassVar
 import requests
 from aoptk.chemical import Chemical
+from aoptk.normalize_chemical import NormalizeChemical
 
 
-class PubChemAbbreviations:
+class PubChemAbbreviations(NormalizeChemical):
     """Find chemical abbreviations via PubChem."""
 
     timeout = 10

--- a/tests/test_pubchem_abbreviations.py
+++ b/tests/test_pubchem_abbreviations.py
@@ -1,5 +1,6 @@
 import pytest
 from aoptk.chemical import Chemical
+from aoptk.normalize_chemical import NormalizeChemical
 from aoptk.pubchem_abbreviations import PubChemAbbreviations
 
 
@@ -7,6 +8,11 @@ def test_can_create():
     """Test that PubChemAbbreviations can be instantiated."""
     actual = PubChemAbbreviations()
     assert actual is not None
+
+
+def test_implements_interface():
+    """Test that PubChemAbbreviations implements NormalizeChemical interface."""
+    assert issubclass(PubChemAbbreviations, NormalizeChemical)
 
 
 def test_normalize_chemical_not_empty():


### PR DESCRIPTION
Try to translate an abbreviation (identified by NER as a chemical) using PubChem (e.g., if you write TAA in PubChem, it will find thioacetamide).

Originally, there was another PR (https://github.com/rdurnik/aoptk/pull/56) but the commited files were not showing and tests were not running on CI. I think because the first commit removed the same files from main (should have pulled first from main instead reverting changes on this branch...).